### PR TITLE
Customer chat sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React component for [Messenger customer chat plugin](https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin)
 
-[![npm](https://img.shields.io/npm/v/react-messenger-customer-chat.svg?style=flat-square)](https://www.npmjs.com/package/react-messenger-customer-chat)
+[![npm](https://img.shields.io/npm/v/react-messenger-customer-chat.svg)](https://www.npmjs.com/package/react-messenger-customer-chat)
 [![Build Status](https://travis-ci.org/Yoctol/react-messenger-customer-chat.svg?branch=master)](https://travis-ci.org/Yoctol/react-messenger-customer-chat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ReactDOM.render(
 ```
 
 > Note: It will handle sdk initialize automatically for you. See more details in
-> [fbsdk official docs](https://developers.facebook.com/docs/javascript/quickstart/).
+> [Customer Chat Plugin official docs](https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin) and [Customer Chat SDK official docs](https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin/sdk).
 
 ## Props
 
@@ -53,6 +53,7 @@ static propTypes = {
   pageId: PropTypes.string.isRequired,
   appId: PropTypes.string.isRequired,
 
+  shouldShowDialog: PropTypes.bool,
   htmlRef: PropTypes.string,
   minimized: PropTypes.bool,
   themeColor: PropTypes.string,
@@ -65,9 +66,12 @@ static propTypes = {
   version: PropTypes.string,
   language: PropTypes.string,
   debug: PropTypes.bool,
+  onCustomerChatDialogShow: PropTypes.func,
+  onCustomerChatDialogHide: PropTypes.func,
 };
 
 static defaultProps = {
+  shouldShowDialog: false,
   htmlRef: undefined,
   minimized: undefined,
   themeColor: undefined,
@@ -80,6 +84,8 @@ static defaultProps = {
   version: '2.11',
   language: 'en_US',
   debug: false,
+  onCustomerChatDialogShow: undefined,
+  onCustomerChatDialogHide: undefined,
 };
 ```
 

--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -78,8 +78,7 @@ export default class MessengerCustomerChat extends Component {
     const { language, debug } = this.props;
     /* eslint-disable */
     (function(d, s, id) {
-      var js,
-        fjs = d.getElementsByTagName(s)[0];
+      var js;
       if (d.getElementById(id)) {
         return;
       }
@@ -88,7 +87,7 @@ export default class MessengerCustomerChat extends Component {
       js.src = `https://connect.facebook.net/${language}/sdk${
         debug ? '/debug' : ''
       }.js`;
-      fjs.parentNode.insertBefore(js, fjs);
+      d.body.prepend(js);
     })(document, 'script', 'facebook-jssdk');
     /* eslint-enable */
   }

--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -18,7 +18,6 @@ export default class MessengerCustomerChat extends Component {
     xfbml: PropTypes.bool,
     version: PropTypes.string,
     language: PropTypes.string,
-    debug: PropTypes.bool,
     onCustomerChatDialogShow: PropTypes.func,
     onCustomerChatDialogHide: PropTypes.func,
   };
@@ -36,7 +35,6 @@ export default class MessengerCustomerChat extends Component {
     xfbml: true,
     version: '2.11',
     language: 'en_US',
-    debug: false,
     onCustomerChatDialogShow: undefined,
     onCustomerChatDialogHide: undefined,
   };
@@ -66,8 +64,7 @@ export default class MessengerCustomerChat extends Component {
       prevProps.autoLogAppEvents !== this.props.autoLogAppEvents ||
       prevProps.xfbml !== this.props.xfbml ||
       prevProps.version !== this.props.version ||
-      prevProps.language !== this.props.language ||
-      prevProps.debug !== this.props.debug
+      prevProps.language !== this.props.language
     ) {
       this.setFbAsyncInit();
       this.reloadSDKAsynchronously();

--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -1,6 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
+const removeElementByIds = ids => {
+  ids.forEach(id => {
+    const element = document.getElementById(id);
+    if (element && element.parentNode) {
+      element.parentNode.removeChild(element);
+    }
+  });
+};
+
 export default class MessengerCustomerChat extends Component {
   static propTypes = {
     pageId: PropTypes.string.isRequired,
@@ -104,15 +113,6 @@ export default class MessengerCustomerChat extends Component {
   }
 
   removeFacebookSDK() {
-    const removeElementByIds = ids => {
-      ids.forEach(id => {
-        const element = document.getElementById(id);
-        if (element.parentNode) {
-          element.parentNode.removeChild(element);
-        }
-      });
-    };
-
     removeElementByIds(['facebook-jssdk', 'fb-root']);
 
     delete window.FB;
@@ -142,6 +142,7 @@ export default class MessengerCustomerChat extends Component {
         onCustomerChatDialogShow
       );
     }
+
     if (onCustomerChatDialogHide) {
       window.FB.Event.subscribe(
         'customerchat.dialogHide',

--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -54,8 +54,6 @@ export default class MessengerCustomerChat extends Component {
   componentDidMount() {
     this.setFbAsyncInit();
     this.reloadSDKAsynchronously();
-    this.controlsPlugin();
-    this.subscribeEvents();
   }
 
   componentDidUpdate(prevProps) {
@@ -79,8 +77,6 @@ export default class MessengerCustomerChat extends Component {
     ) {
       this.setFbAsyncInit();
       this.reloadSDKAsynchronously();
-      this.controlsPlugin();
-      this.subscribeEvents();
     }
   }
 
@@ -94,6 +90,7 @@ export default class MessengerCustomerChat extends Component {
         xfbml,
         version: `v${version}`,
       });
+
       this.setState({ fbLoaded: true });
     };
   }
@@ -142,50 +139,42 @@ export default class MessengerCustomerChat extends Component {
   }
 
   controlsPlugin() {
-    const { fbLoaded } = this.state;
+    const { shouldShowPlugin, shouldShowDialog } = this.props;
 
-    if (fbLoaded) {
-      const { shouldShowPlugin, shouldShowDialog } = this.props;
+    window.FB.CustomerChat.show(shouldShowPlugin);
 
-      window.FB.CustomerChat.show(shouldShowPlugin);
-
-      if (shouldShowDialog) {
-        window.FB.CustomerChat.showDialog();
-      } else {
-        window.FB.CustomerChat.hideDialog();
-      }
+    if (shouldShowDialog) {
+      window.FB.CustomerChat.showDialog();
+    } else {
+      window.FB.CustomerChat.hideDialog();
     }
   }
 
   subscribeEvents() {
-    const { fbLoaded } = this.state;
+    const {
+      onCustomerChatShow,
+      onCustomerChatHide,
+      onCustomerChatDialogShow,
+      onCustomerChatDialogHide,
+    } = this.props;
 
-    if (fbLoaded) {
-      const {
-        onCustomerChatShow,
-        onCustomerChatHide,
-        onCustomerChatDialogShow,
-        onCustomerChatDialogHide,
-      } = this.props;
-
-      if (onCustomerChatShow) {
-        window.FB.Event.subscribe('customerchat.show', onCustomerChatShow);
-      }
-      if (onCustomerChatHide) {
-        window.FB.Event.subscribe('customerchat.hide', onCustomerChatHide);
-      }
-      if (onCustomerChatDialogShow) {
-        window.FB.Event.subscribe(
-          'customerchat.dialogShow',
-          onCustomerChatDialogShow
-        );
-      }
-      if (onCustomerChatDialogHide) {
-        window.FB.Event.subscribe(
-          'customerchat.dialogHide',
-          onCustomerChatDialogHide
-        );
-      }
+    if (onCustomerChatShow) {
+      window.FB.Event.subscribe('customerchat.show', onCustomerChatShow);
+    }
+    if (onCustomerChatHide) {
+      window.FB.Event.subscribe('customerchat.hide', onCustomerChatHide);
+    }
+    if (onCustomerChatDialogShow) {
+      window.FB.Event.subscribe(
+        'customerchat.dialogShow',
+        onCustomerChatDialogShow
+      );
+    }
+    if (onCustomerChatDialogHide) {
+      window.FB.Event.subscribe(
+        'customerchat.dialogHide',
+        onCustomerChatDialogHide
+      );
     }
   }
 
@@ -239,6 +228,12 @@ export default class MessengerCustomerChat extends Component {
   }
 
   render() {
+    const { fbLoaded } = this.state;
+
+    if (fbLoaded) {
+      this.controlsPlugin();
+      this.subscribeEvents();
+    }
     // Add a random key to rerender. Reference:
     // https://stackoverflow.com/questions/30242530/dangerouslysetinnerhtml-doesnt-update-during-render
     return <div key={Date()} dangerouslySetInnerHTML={this.createMarkup()} />;

--- a/src/__tests__/MessengerCustomerChat.spec.js
+++ b/src/__tests__/MessengerCustomerChat.spec.js
@@ -23,6 +23,13 @@ beforeEach(() => {
       removeChild: jest.fn(),
     },
   }));
+  document.addEventListener = jest.fn((_, cb) =>
+    cb({
+      target: {
+        className: 'fb_dialog',
+      },
+    })
+  );
 });
 
 describe('<MessengerCustomerChat />', () => {
@@ -121,7 +128,6 @@ describe('<MessengerCustomerChat />', () => {
         subscribe: jest.fn(),
       },
       CustomerChat: {
-        show: jest.fn(),
         showDialog: jest.fn(),
         hideDialog: jest.fn(),
       },
@@ -135,8 +141,8 @@ describe('<MessengerCustomerChat />', () => {
       xfbml: true,
       version: 'v2.11',
     });
-    expect(global.FB.CustomerChat.show).toBeCalledWith(true);
-    expect(global.FB.CustomerChat.hideDialog).toBeCalled();
+
+    expect(global.FB.CustomerChat.hideDialog).toHaveBeenCalledTimes(1);
   });
 
   it('define shouldShowPlugin, shouldShowDialog and call FB SDK', () => {
@@ -144,7 +150,6 @@ describe('<MessengerCustomerChat />', () => {
       <MessengerCustomerChat
         pageId="<PAGE_ID>"
         appId="<APP_ID>"
-        shouldShowPlugin
         shouldShowDialog
       />
     );
@@ -155,7 +160,6 @@ describe('<MessengerCustomerChat />', () => {
         subscribe: jest.fn(),
       },
       CustomerChat: {
-        show: jest.fn(),
         showDialog: jest.fn(),
         hideDialog: jest.fn(),
       },
@@ -163,14 +167,11 @@ describe('<MessengerCustomerChat />', () => {
 
     global.fbAsyncInit();
 
-    expect(global.FB.CustomerChat.show).toBeCalledWith(true);
-    expect(global.FB.CustomerChat.showDialog).toBeCalled();
+    expect(global.FB.CustomerChat.showDialog).toHaveBeenCalledTimes(1);
     expect(global.FB.CustomerChat.hideDialog).not.toBeCalled();
   });
 
   it('define event handlers props and call FB SDK', () => {
-    const onCustomerChatShow = () => {};
-    const onCustomerChatHide = () => {};
     const onCustomerChatDialogShow = () => {};
     const onCustomerChatDialogHide = () => {};
 
@@ -178,8 +179,6 @@ describe('<MessengerCustomerChat />', () => {
       <MessengerCustomerChat
         pageId="<PAGE_ID>"
         appId="<APP_ID>"
-        onCustomerChatShow={onCustomerChatShow}
-        onCustomerChatHide={onCustomerChatHide}
         onCustomerChatDialogShow={onCustomerChatDialogShow}
         onCustomerChatDialogHide={onCustomerChatDialogHide}
       />
@@ -191,7 +190,6 @@ describe('<MessengerCustomerChat />', () => {
         subscribe: jest.fn(),
       },
       CustomerChat: {
-        show: jest.fn(),
         showDialog: jest.fn(),
         hideDialog: jest.fn(),
       },
@@ -199,14 +197,6 @@ describe('<MessengerCustomerChat />', () => {
 
     global.fbAsyncInit();
 
-    expect(global.FB.Event.subscribe).toBeCalledWith(
-      'customerchat.show',
-      onCustomerChatShow
-    );
-    expect(global.FB.Event.subscribe).toBeCalledWith(
-      'customerchat.hide',
-      onCustomerChatHide
-    );
     expect(global.FB.Event.subscribe).toBeCalledWith(
       'customerchat.dialogShow',
       onCustomerChatDialogShow

--- a/src/__tests__/MessengerCustomerChat.spec.js
+++ b/src/__tests__/MessengerCustomerChat.spec.js
@@ -97,7 +97,7 @@ describe('<MessengerCustomerChat />', () => {
     expect(customerchat.prop('greeting_dialog_delay')).toBe('3');
   });
 
-  it('define fbAsyncInit and call loadSDKAsynchronously when facebook-jssdk does not exist', () => {
+  it('define fbAsyncInit and call loadSDKAsynchronously', () => {
     mount(<MessengerCustomerChat pageId="<PAGE_ID>" appId="<APP_ID>" />);
 
     expect(global.fbAsyncInit).toBeDefined();
@@ -117,6 +117,14 @@ describe('<MessengerCustomerChat />', () => {
 
     global.FB = {
       init: jest.fn(),
+      Event: {
+        subscribe: jest.fn(),
+      },
+      CustomerChat: {
+        show: jest.fn(),
+        showDialog: jest.fn(),
+        hideDialog: jest.fn(),
+      },
     };
 
     global.fbAsyncInit();
@@ -127,5 +135,54 @@ describe('<MessengerCustomerChat />', () => {
       xfbml: true,
       version: 'v2.11',
     });
+  });
+
+  it('define event handlers props and call FB SDK', () => {
+    const onCustomerChatShow = () => {};
+    const onCustomerChatHide = () => {};
+    const onCustomerChatDialogShow = () => {};
+    const onCustomerChatDialogHide = () => {};
+
+    mount(
+      <MessengerCustomerChat
+        pageId="<PAGE_ID>"
+        appId="<APP_ID>"
+        onCustomerChatShow={onCustomerChatShow}
+        onCustomerChatHide={onCustomerChatHide}
+        onCustomerChatDialogShow={onCustomerChatDialogShow}
+        onCustomerChatDialogHide={onCustomerChatDialogHide}
+      />
+    );
+
+    global.FB = {
+      init: jest.fn(),
+      Event: {
+        subscribe: jest.fn(),
+      },
+      CustomerChat: {
+        show: jest.fn(),
+        showDialog: jest.fn(),
+        hideDialog: jest.fn(),
+      },
+    };
+
+    global.fbAsyncInit();
+
+    expect(global.FB.Event.subscribe).toBeCalledWith(
+      'customerchat.show',
+      onCustomerChatShow
+    );
+    expect(global.FB.Event.subscribe).toBeCalledWith(
+      'customerchat.hide',
+      onCustomerChatHide
+    );
+    expect(global.FB.Event.subscribe).toBeCalledWith(
+      'customerchat.dialogShow',
+      onCustomerChatDialogShow
+    );
+    expect(global.FB.Event.subscribe).toBeCalledWith(
+      'customerchat.dialogHide',
+      onCustomerChatDialogHide
+    );
   });
 });

--- a/src/__tests__/MessengerCustomerChat.spec.js
+++ b/src/__tests__/MessengerCustomerChat.spec.js
@@ -135,6 +135,37 @@ describe('<MessengerCustomerChat />', () => {
       xfbml: true,
       version: 'v2.11',
     });
+    expect(global.FB.CustomerChat.show).toBeCalledWith(true);
+    expect(global.FB.CustomerChat.hideDialog).toBeCalled();
+  });
+
+  it('define shouldShowPlugin, shouldShowDialog and call FB SDK', () => {
+    mount(
+      <MessengerCustomerChat
+        pageId="<PAGE_ID>"
+        appId="<APP_ID>"
+        shouldShowPlugin
+        shouldShowDialog
+      />
+    );
+
+    global.FB = {
+      init: jest.fn(),
+      Event: {
+        subscribe: jest.fn(),
+      },
+      CustomerChat: {
+        show: jest.fn(),
+        showDialog: jest.fn(),
+        hideDialog: jest.fn(),
+      },
+    };
+
+    global.fbAsyncInit();
+
+    expect(global.FB.CustomerChat.show).toBeCalledWith(true);
+    expect(global.FB.CustomerChat.showDialog).toBeCalled();
+    expect(global.FB.CustomerChat.hideDialog).not.toBeCalled();
   });
 
   it('define event handlers props and call FB SDK', () => {


### PR DESCRIPTION
close #22 
This PR will cause breaking change.

1. Replace original SDK source with `https://connect.facebook.net/${language}/sdk/xfbml.customerchat.js`
2. Remove props: `debug`
3. Add three new props: `shouldShowDialog`, `onCustomerChatDialogShow` and `onCustomerChatDialogHide`