### PR TITLE
add undefined check

### DIFF
--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -208,7 +208,7 @@ export default class MessengerCustomerChat extends Component {
         'DOMNodeInserted',
         event => {
           const element = event.target;
-          if (element.className.includes('fb_dialog')) {
+          if (element.className && element.className.includes('fb_dialog')) {
             this.controlPlugin();
           }
         },


### PR DESCRIPTION
add ```undefined``` check to ```element.className```
to avoid ```TypeError: Cannot read property 'includes' of undefined ```