### PR TITLE
Check if 'includes' is callable on inserted DOMNode

### DIFF
--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -208,7 +208,11 @@ export default class MessengerCustomerChat extends Component {
         'DOMNodeInserted',
         event => {
           const element = event.target;
-          if (element.className && element.className.includes('fb_dialog')) {
+          if (
+            element.className &&
+            typeof element.className.includes === 'function' &&
+            element.className.includes('fb_dialog')
+          ) {
             this.controlPlugin();
           }
         },

--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -210,7 +210,7 @@ export default class MessengerCustomerChat extends Component {
           const element = event.target;
           if (
             element.className &&
-            typeof element.className.includes === 'function' &&
+            typeof element.className === 'string' &&
             element.className.includes('fb_dialog')
           ) {
             this.controlPlugin();


### PR DESCRIPTION
## Summary
This issue takes into account that `includes` function may not exist. Other than browser incompatibility (which is highly unlikely since [browsers support this feature for quite a while](https://caniuse.com/#feat=array-includes)), this might happen because [`className` is not guaranteed to be a `string` every time](https://developer.mozilla.org/en-US/docs/Web/API/Element/className#Notes).

## Proposed solution
We just check if `includes` is a function when adding a new DOM Node.

## Issues
This PR _might_ solve issue #31 