### PR TITLE
CLOSES #50 Hide messenger chat on component unmount

### DIFF
--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -80,6 +80,12 @@ export default class MessengerCustomerChat extends Component {
     }
   }
 
+  componentWillUnmount() {
+    if (window.FB !== undefined) {
+      window.FB.CustomerChat.hide();
+    }
+  }
+
   setFbAsyncInit() {
     const { appId, autoLogAppEvents, xfbml, version } = this.props;
 

--- a/src/__tests__/MessengerCustomerChat.spec.js
+++ b/src/__tests__/MessengerCustomerChat.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -205,5 +209,35 @@ describe('<MessengerCustomerChat />', () => {
       'customerchat.dialogHide',
       onCustomerChatDialogHide
     );
+  });
+
+  it('unmount calls fb hide', () => {
+    const component = mount(
+      <MessengerCustomerChat
+        pageId="<PAGE_ID>"
+        appId="<APP_ID>"
+        autoLogAppEvents
+        xfbml
+        version="2.11"
+      />
+    );
+
+    global.FB = {
+      init: jest.fn(),
+      Event: {
+        subscribe: jest.fn(),
+      },
+      CustomerChat: {
+        showDialog: jest.fn(),
+        hideDialog: jest.fn(),
+        hide: jest.fn(),
+      },
+    };
+
+    global.fbAsyncInit();
+
+    component.unmount();
+
+    expect(global.FB.CustomerChat.hide).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import MessengerCustomerChat from '../';
 
 it('should export component', () => {


### PR DESCRIPTION
CLOSES #50 
CLOSES #38 

When using `<MessengerChatPlugin>` if you don't want to display it on every page it is helpful that when the component is unmounted to hide the FB Messenger chat, otherwise it will render everywhere even after the react component is removed from the rendered DOM.