### PR TITLE
fix: props.appId should be optional

### DIFF
--- a/src/MessengerCustomerChat.js
+++ b/src/MessengerCustomerChat.js
@@ -13,8 +13,7 @@ const removeElementByIds = ids => {
 export default class MessengerCustomerChat extends Component {
   static propTypes = {
     pageId: PropTypes.string.isRequired,
-    appId: PropTypes.string.isRequired,
-
+    appId: PropTypes.string,
     shouldShowDialog: PropTypes.bool,
     htmlRef: PropTypes.string,
     minimized: PropTypes.bool,
@@ -32,6 +31,7 @@ export default class MessengerCustomerChat extends Component {
   };
 
   static defaultProps = {
+    appId: null,
     shouldShowDialog: false,
     htmlRef: undefined,
     minimized: undefined,


### PR DESCRIPTION
close #40 

`appId` is used to call `FB.init`:

```js
window.fbAsyncInit = function() {
    FB.init({
      appId            : 'your-app-id',
      autoLogAppEvents : true,
      xfbml            : true,
      version          : 'v7.0'
    });
};
```

It's default value is `null`:

<img width="1021" alt="截圖 2020-06-30 上午1 50 39" src="https://user-images.githubusercontent.com/3382565/86038855-2a7c8e00-ba74-11ea-9e47-65f55be3ca2f.png">
